### PR TITLE
Implemented replacement of when declarations

### DIFF
--- a/when.js
+++ b/when.js
@@ -8,6 +8,11 @@ export class WhenMock {
     this.log = (...args) => this.debug && console.log(...args);
 
     const mockReturnValue = (matchers, assertCall) => (val) => {
+      // Remove call mocks with equal matchers to enable dynamic remplacement during a test
+      this.callMocks = this.callMocks.filter((callMock) => {
+        return !equals(callMock.matchers, matchers);
+      });
+
       this.callMocks.push({ matchers, val, assertCall });
 
       this.fn.mockImplementation((...args) => {

--- a/when.spec.js
+++ b/when.spec.js
@@ -73,6 +73,16 @@ describe('When', () => {
       expect(fn(false, /asdf/g)).toEqual('z');
     });
 
+    it('supports replacement of when declarations', () => {
+      const fn = jest.fn();
+
+      when(fn).calledWith('foo', 'bar').mockReturnValue('x');
+      when(fn).calledWith(false, /asdf/g).mockReturnValue('y');
+      when(fn).calledWith('foo', 'bar').mockReturnValue('z');
+
+      expect(fn('foo', 'bar')).toEqual('z');
+    });
+
     it('expectCalledWith: fails a test with error messaging if argument does not match', () => {
       const fn1 = jest.fn();
       const fn2 = jest.fn();


### PR DESCRIPTION
jest-when is a nice approach to introduce a concept to jest which well known from other mocking tools like sinon.

However i've missed the feature to replace mock implementations within a test. For convenience i'm used to declare default implementations within the `beforeEach()`. But sometimes a single test requires a different behavior of the mock.

That is't possible at the moment since every call of `when(fn).calledWith()` pushes a new entry to the `callMocks`. When the `mockImplementation()` searches for a suitable `callMock` the first match wins the bid.

This pull request proposes a way to implement the missed functionality.