### PR TITLE
Expose a reset to allow clearing mocks between tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,28 @@ expect(cb).toBeCalled()
 
 Thanks to [@idan-at](https://github.com/idan-at).
 
+#### Supports reseting mocks between tests
+
+You could use this to prevent mocks from carrying state between tests or assertions.
+
+```javascript
+const { when, resetAllWhenMocks } = require('jest-when')
+const fn = jest.fn()
+
+when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+expect(fn(1)).toEqual('x')
+
+resetAllWhenMocks()
+
+when(fn).expectCalledWith(1).mockReturnValueOnce('z')
+
+expect(fn(1)).toEqual('z')
+```
+
+Thanks to [@whoaa512](https://github.com/whoaa512).
+
+
 ### Contributors (in order of contribution)
 * [@timkindberg](https://github.com/timkindberg/) (original author)
 * [@jonasholtkamp](https://github.com/jonasholtkamp) (forked @ https://github.com/jonasholtkamp/jest-when-xt)

--- a/src/when.js
+++ b/src/when.js
@@ -1,6 +1,8 @@
 const utils = require('expect/build/jasmine_utils')
 const logger = require('./log')('when')
 
+let registry = new Set()
+
 const checkArgumentMatchers = (assertCall, args) => (match, matcher, i) => {
   logger.debug(`matcher check, match: ${match}, index: ${i}`)
 
@@ -104,10 +106,21 @@ class WhenMock {
 const when = (fn) => {
   if (fn.__whenMock__ instanceof WhenMock) return fn.__whenMock__
   fn.__whenMock__ = new WhenMock(fn)
+  registry.add(fn)
   return fn.__whenMock__
 }
 
+const resetAllWhenMocks = () => {
+  registry.forEach(fn => {
+    fn.__whenMock__ = undefined
+  })
+  registry = new Set()
+}
+
+when.resetAllWhenMocks = resetAllWhenMocks
+
 module.exports = {
   when,
+  resetAllWhenMocks,
   WhenMock
 }

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -4,7 +4,7 @@ const errMsg = ({ expect, actual }) =>
   new RegExp(`Expected.*\\n.*${expect}.*\\nReceived.*\\n.*${actual}`)
 
 describe('When', () => {
-  let spyEquals, when, WhenMock, mockLogger
+  let spyEquals, when, WhenMock, mockLogger, resetAllWhenMocks
 
   beforeEach(() => {
     spyEquals = jest.spyOn(require('expect/build/jasmine_utils'), 'equals')
@@ -21,6 +21,7 @@ describe('When', () => {
     jest.mock('./log', () => () => mockLogger)
 
     when = require('./when').when
+    resetAllWhenMocks = require('./when').resetAllWhenMocks
     WhenMock = require('./when').WhenMock
   })
 
@@ -46,6 +47,18 @@ describe('When', () => {
       expect(whenFn1).toBeInstanceOf(WhenMock)
       expect(whenFn2).toBeInstanceOf(WhenMock)
       expect(whenFn1).toBe(whenFn2)
+    })
+
+    it('allows reset of mocks to enable overrides later', () => {
+      const fn = jest.fn()
+
+      when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+      resetAllWhenMocks()
+
+      when(fn).expectCalledWith(1).mockReturnValueOnce('z')
+
+      expect(fn(1)).toEqual('z')
     })
   })
 


### PR DESCRIPTION

When using the `expectCalledWith` helper there is a weird case where
if a mock does not get used and a following test tries to mock the same
thing for a different purpose it causes cascading test failures unless
you manually clear the `__whenMock__` before or after each test.

This simply adds a helper to clear them all at once.
