### PR TITLE
Don't reject promises until mock functions are called

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -87,8 +87,8 @@ class WhenMock {
       mockReturnValueOnce: val => _mockReturnValue(matchers, assertCall, true)(val),
       mockResolvedValue: val => _mockReturnValue(matchers, assertCall)(Promise.resolve(val)),
       mockResolvedValueOnce: val => _mockReturnValue(matchers, assertCall, true)(Promise.resolve(val)),
-      mockRejectedValue: err => _mockReturnValue(matchers, assertCall)(Promise.reject(err)),
-      mockRejectedValueOnce: err => _mockReturnValue(matchers, assertCall, true)(Promise.reject(err)),
+      mockRejectedValue: err => _mockReturnValue(matchers, assertCall)(() => Promise.reject(err)),
+      mockRejectedValueOnce: err => _mockReturnValue(matchers, assertCall, true)(() => Promise.reject(err)),
       mockImplementation: implementation => _mockReturnValue(matchers, assertCall)(implementation),
       mockImplementationOnce: implementation => _mockReturnValue(matchers, assertCall, true)(implementation)
     })

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -250,6 +250,17 @@ describe('When', () => {
       await expect(fn('foo')).rejects.toThrow('bar')
     })
 
+    it('mockRejectedValue: does not reject the Promise until the function is called', done => {
+      const fn = jest.fn()
+
+      when(fn).calledWith('foo').mockRejectedValue(new Error('bar'))
+
+      setTimeout(async () => {
+        await expect(fn('foo')).rejects.toThrow('bar')
+        done()
+      }, 0)
+    })
+
     it('mockRejectedValue: works with expectCalledWith', async () => {
       const fn = jest.fn()
 
@@ -265,6 +276,17 @@ describe('When', () => {
 
       await expect(fn('foo')).rejects.toThrow('bar')
       expect(await fn('foo')).toBeUndefined()
+    })
+
+    it('mockRejectedValueOnce: does not reject the Promise until the function is called', done => {
+      const fn = jest.fn()
+
+      when(fn).calledWith('foo').mockRejectedValueOnce(new Error('bar'))
+
+      setTimeout(async () => {
+        await expect(fn('foo')).rejects.toThrow('bar')
+        done()
+      }, 0)
     })
 
     it('mockRejectedValueOnce: works with expectCalledWith', async () => {


### PR DESCRIPTION
jest-when has the same issue as https://github.com/facebook/jest/issues/5721 (which was fixed in https://github.com/facebook/jest/pull/5720) - `mockRejectedValue` causes an error if the mock function is called asynchronously, because the returned promise was rejected immediately.

This PR changes `mockRejectedValue[Once]` to defer the promise rejection until the mock function is actually called.