### PR TITLE
Verify mocks called v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,32 @@ expect(fn(1)).toEqual('z')
 
 Thanks to [@whoaa512](https://github.com/whoaa512).
 
+#### Supports verifying that all mocked functions were called
+
+Call `verifyAllWhenMocksCalled` after your test to assert that all mocks were used.
+
+```javascript
+const { when, verifyAllWhenMocksCalled } = require('jest-when')
+const fn = jest.fn()
+
+when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+expect(fn(1)).toEqual('x')
+
+verifyAllWhenMocksCalled() // passes
+```
+
+```javascript
+const { when, verifyAllWhenMocksCalled } = require('jest-when')
+const fn = jest.fn()
+
+when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+verifyAllWhenMocksCalled() // fails
+```
+
+Thanks to [@roaclark](https://github.com/roaclark).
+
 
 ### Contributors (in order of contribution)
 * [@timkindberg](https://github.com/timkindberg/) (original author)
@@ -226,4 +252,6 @@ Thanks to [@whoaa512](https://github.com/whoaa512).
 * [@fkloes](https://github.com/fkloes)
 * [@danielhusar](https://github.com/danielhusar)
 * [@idan-at](https://github.com/idan-at)
+* [@whoaa512](https://github.com/whoaa512).
+* [@roaclark](https://github.com/roaclark)
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -83,17 +83,15 @@ describe('When', () => {
       const fn1 = jest.fn()
       const fn2 = jest.fn()
 
-      when(fn1).expectCalledWith(1).mockReturnValue('z')
-      when(fn2).expectCalledWith(1).mockReturnValueOnce('x')
-      when(fn2).expectCalledWith(1).mockReturnValueOnce('y')
-      when(fn2).expectCalledWith(1).mockReturnValue('z')
+      when(fn1).expectCalledWith(expect.anything()).mockReturnValue('z')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('x')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('y')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValue('z')
 
       fn1(1)
       fn2(1)
-      fn2(1)
 
-      const error = new RegExp(`Expected value to equal:\\n.*"hasBeenCalled": true`)
-      expect(verifyAllWhenMocksCalled).toThrow(error)
+      expect(verifyAllWhenMocksCalled).toThrow(/Failed verifyAllWhenMocksCalled: 2 not called/)
     })
   })
 
@@ -441,7 +439,7 @@ describe('When', () => {
       when(fn)
         .mockReturnValue('default')
 
-      expect(fn).toThrow('Uninteded use: Only use default value in combination with .calledWith(..), ' +
+      expect(fn).toThrow('Unintended use: Only use default value in combination with .calledWith(..), ' +
         'or use standard mocking without jest-when.')
     })
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -4,7 +4,7 @@ const errMsg = ({ expect, actual }) =>
   new RegExp(`Expected.*\\n.*${expect}.*\\nReceived.*\\n.*${actual}`)
 
 describe('When', () => {
-  let spyEquals, when, WhenMock, mockLogger, resetAllWhenMocks
+  let spyEquals, when, WhenMock, mockLogger, resetAllWhenMocks, verifyAllWhenMocksCalled
 
   beforeEach(() => {
     spyEquals = jest.spyOn(require('expect/build/jasmine_utils'), 'equals')
@@ -22,6 +22,7 @@ describe('When', () => {
 
     when = require('./when').when
     resetAllWhenMocks = require('./when').resetAllWhenMocks
+    verifyAllWhenMocksCalled = require('./when').verifyAllWhenMocksCalled
     WhenMock = require('./when').WhenMock
   })
 
@@ -59,6 +60,40 @@ describe('When', () => {
       when(fn).expectCalledWith(1).mockReturnValueOnce('z')
 
       expect(fn(1)).toEqual('z')
+    })
+
+    it('allows checking that all mocks were called', () => {
+      const fn1 = jest.fn()
+      const fn2 = jest.fn()
+
+      when(fn1).expectCalledWith(1).mockReturnValue('z')
+      when(fn2).expectCalledWith(1).mockReturnValueOnce('x')
+      when(fn2).expectCalledWith(1).mockReturnValueOnce('y')
+      when(fn2).expectCalledWith(1).mockReturnValue('z')
+
+      fn1(1)
+      fn2(1)
+      fn2(1)
+      fn2(1)
+
+      expect(verifyAllWhenMocksCalled).not.toThrow()
+    })
+
+    it('fails verification check if all mocks were not called', () => {
+      const fn1 = jest.fn()
+      const fn2 = jest.fn()
+
+      when(fn1).expectCalledWith(1).mockReturnValue('z')
+      when(fn2).expectCalledWith(1).mockReturnValueOnce('x')
+      when(fn2).expectCalledWith(1).mockReturnValueOnce('y')
+      when(fn2).expectCalledWith(1).mockReturnValue('z')
+
+      fn1(1)
+      fn2(1)
+      fn2(1)
+
+      const error = new RegExp(`Expected value to equal:\\n.*"hasBeenCalled": true`)
+      expect(verifyAllWhenMocksCalled).toThrow(error)
     })
   })
 


### PR DESCRIPTION
@roaclark Hey I mucked around with it, and did a bit of a mashup between your two ideas, plus a little extra to get the error diff to show up a little more nicely by renaming some internal fields. I thought it would be odd to do a PR into your PR so I just pushed a new local branch that we can review together.

The error now looks like this. It shows how many mocks weren't called, and a diff between each one. I'm good with this if you are.
```
Error: expect(received).toEqual(expected)

Expected value to equal:
  ["Failed verifyAllWhenMocksCalled: 2 not called", [{"called": true, "expectCall": true, "matchers": [Anything], "once": true, "returnValue": "y"}, {"called": true, "expectCall": true, "matchers": [Anything], "once": false, "returnValue": "z"}]]
Received:
  ["Failed verifyAllWhenMocksCalled: 2 not called", [{"called": false, "expectCall": true, "matchers": [], "once": true, "returnValue": "y"}, {"called": false, "expectCall": true, "matchers": [], "once": false, "returnValue": "z"}]]

Difference:

- Expected
+ Received

  Array [
    "Failed verifyAllWhenMocksCalled: 2 not called",
    Array [
      Object {
-       "called": true,
+       "called": false,
        "expectCall": true,
-       "matchers": Array [
-         Anything,
-       ],
+       "matchers": Array [],
        "once": true,
        "returnValue": "y",
      },
      Object {
-       "called": true,
+       "called": false,
        "expectCall": true,
-       "matchers": Array [
-         Anything,
-       ],
+       "matchers": Array [],
        "once": false,
        "returnValue": "z",
      },
    ],
  ] <Click to see difference>
```