### PR TITLE
Change verifyAllWhenMocksCalled to output the line numbers

### DIFF
--- a/src/__snapshots__/when.test.js.snap
+++ b/src/__snapshots__/when.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When when fails verification check if all mocks were not called with line numbers 1`] = `
+"Failed verifyAllWhenMocksCalled: 2 not called at:
+
+at Object.it (/Users/cjw/code/jest-when/src/when.test.js:103:53)
+at Object.it (/Users/cjw/code/jest-when/src/when.test.js:104:53)"
+`;

--- a/src/__snapshots__/when.test.js.snap
+++ b/src/__snapshots__/when.test.js.snap
@@ -1,8 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`When when fails verification check if all mocks were not called with line numbers 1`] = `
-"Failed verifyAllWhenMocksCalled: 2 not called at:
-
-at Object.it (/Users/cjw/code/jest-when/src/when.test.js:103:53)
-at Object.it (/Users/cjw/code/jest-when/src/when.test.js:104:53)"
-`;

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -106,7 +106,7 @@ describe('When', () => {
       fn1(1)
       fn2(1)
 
-      expect(verifyAllWhenMocksCalled).toThrowErrorMatchingSnapshot()
+      expect(verifyAllWhenMocksCalled).toThrow(/src\/when\.test\.js:\d{3}/)
     })
   })
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -93,6 +93,21 @@ describe('When', () => {
 
       expect(verifyAllWhenMocksCalled).toThrow(/Failed verifyAllWhenMocksCalled: 2 not called/)
     })
+
+    it('fails verification check if all mocks were not called with line numbers', () => {
+      const fn1 = jest.fn()
+      const fn2 = jest.fn()
+
+      when(fn1).expectCalledWith(expect.anything()).mockReturnValue('z')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('x')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('y')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValue('z')
+
+      fn1(1)
+      fn2(1)
+
+      expect(verifyAllWhenMocksCalled).toThrowErrorMatchingSnapshot()
+    })
   })
 
   describe('mock implementation', () => {


### PR DESCRIPTION
For easier debugging


Example output
```bash
 FAIL  src/apis/GraphQLServer/resolvers/QuoteModelRevision/__tests__/resolver/Mutation.js
  QuoteModelRevisionResolver.Mutation
    ✕ .updateConfigOnQuoteModelRevision happy path (no existing dfmInspection) (53ms)
    ○ skipped 19 tests

  ● QuoteModelRevisionResolver.Mutation › .updateConfigOnQuoteModelRevision happy path (no existing dfmInspection)

    assert.equal(received, expected) or assert(received)

    Expected value to be (operator: ==):
      true
    Received:
      false

    Message:
      Failed verifyAllWhenMocksCalled: 1 not called at:

    at Object.<anonymous> (/Users/cjw/work/apis/src/apis/GraphQLServer/resolvers/QuoteModelRevision/__tests__/resolver/Mutation.js:2034:9)

      2032 |         when(ToolData.find)
      2033 |             .expectCalledWith({}, { transacting })
    > 2034 |             .mockResolvedValueOnce([])
      2035 |
      2036 |         when(
      2037 |             MaterialStockService.prototype


      at Object.<anonymous> (src/apis/GraphQLServer/resolvers/QuoteModelRevision/__tests__/resolver/Mutation.js:2034:9)
      at registry.forEach.fn (node_modules/jest-when/src/when.js:143:12)
          at Set.forEach (<anonymous>)
      at Function.verifyAllWhenMocksCalled (node_modules/jest-when/src/when.js:130:12)
      at Object.afterEach (src/apis/GraphQLServer/resolvers/QuoteModelRevision/__tests__/resolver/Mutation.js:147:24)
```