### PR TITLE
Whoaa512 calllines

### DIFF
--- a/src/__snapshots__/when.test.js.snap
+++ b/src/__snapshots__/when.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When when fails verification check if all mocks were not called with line numbers 1`] = `
+"Failed verifyAllWhenMocksCalled: 2 not called at:
+
+at Object.it (/Users/cjw/code/jest-when/src/when.test.js:103:53)
+at Object.it (/Users/cjw/code/jest-when/src/when.test.js:104:53)"
+`;

--- a/src/__snapshots__/when.test.js.snap
+++ b/src/__snapshots__/when.test.js.snap
@@ -1,8 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`When when fails verification check if all mocks were not called with line numbers 1`] = `
-"Failed verifyAllWhenMocksCalled: 2 not called at:
-
-at Object.it (/Users/cjw/code/jest-when/src/when.test.js:103:53)
-at Object.it (/Users/cjw/code/jest-when/src/when.test.js:104:53)"
-`;

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -106,7 +106,7 @@ describe('When', () => {
       fn1(1)
       fn2(1)
 
-      expect(verifyAllWhenMocksCalled).toThrowErrorMatchingSnapshot()
+      expect(verifyAllWhenMocksCalled).toThrow(/src\/when\.test\.js:\d{3}/)
     })
   })
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -93,6 +93,21 @@ describe('When', () => {
 
       expect(verifyAllWhenMocksCalled).toThrow(/Failed verifyAllWhenMocksCalled: 2 not called/)
     })
+
+    it('fails verification check if all mocks were not called with line numbers', () => {
+      const fn1 = jest.fn()
+      const fn2 = jest.fn()
+
+      when(fn1).expectCalledWith(expect.anything()).mockReturnValue('z')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('x')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValueOnce('y')
+      when(fn2).expectCalledWith(expect.anything()).mockReturnValue('z')
+
+      fn1(1)
+      fn2(1)
+
+      expect(verifyAllWhenMocksCalled).toThrowErrorMatchingSnapshot()
+    })
   })
 
   describe('mock implementation', () => {

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -91,7 +91,17 @@ describe('When', () => {
       fn1(1)
       fn2(1)
 
-      expect(verifyAllWhenMocksCalled).toThrow(/Failed verifyAllWhenMocksCalled: 2 not called/)
+      let caughtErr
+
+      try {
+        verifyAllWhenMocksCalled()
+      } catch (e) {
+        caughtErr = e
+      }
+
+      expect(caughtErr.expected).toEqual('called mocks: 4')
+      expect(caughtErr.actual).toEqual('called mocks: 2')
+      expect(caughtErr.message).toMatch(/Failed verifyAllWhenMocksCalled: 2 not called/)
     })
 
     it('fails verification check if all mocks were not called with line numbers', () => {
@@ -106,7 +116,8 @@ describe('When', () => {
       fn1(1)
       fn2(1)
 
-      expect(verifyAllWhenMocksCalled).toThrow(/src\/when\.test\.js:\d{3}/)
+      // Should be two call lines printed, hence the {2} at the end of the regex
+      expect(verifyAllWhenMocksCalled).toThrow(/(src\/when\.test\.js:\d{3}(.|\s)*){2}/)
     })
   })
 


### PR DESCRIPTION
@Whoaa512 I wanted to add a little bit onto what you did. Here's the resulting test log output:

```bash
assert.equal(received, expected) or assert(received) 
Expected value to be equal to:
  "called mocks: 4"
Received:
  "called mocks: 2"

Message:
  Failed verifyAllWhenMocksCalled: 2 not called at:
  at Object.it (/Users/tim/projects/jest-when/src/when.test.js:113:53)
  at Object.it (/Users/tim/projects/jest-when/src/when.test.js:114:53)


...rest of the stack...
    at verifyAllWhenMocksCalled (/Users/tim/projects/jest-when/src/when.js:136:10)
    at Object.it (/Users/tim/projects/jest-when/src/when.test.js:119:7)
    at Object.asyncFn (/Users/tim/projects/jest-when/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
    at resolve (/Users/tim/projects/jest-when/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
    at new Promise (<anonymous>)
    at mapper (/Users/tim/projects/jest-when/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
    at promise.then (/Users/tim/projects/jest-when/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
    at processTicksAndRejections (internal/process/next_tick.js:81:5) thrown

```