### PR TITLE
Fix `resetAllWhenMocks` to put back original function implementation 

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -32,6 +32,7 @@ class WhenMock {
     this.nextCallMockId = 0
     this.fn = fn
     this.callMocks = []
+    this._origMock = fn.getMockImplementation()
 
     if (defaultValue.isSet) {
       this.fn.mockImplementation(() => {
@@ -111,6 +112,7 @@ const when = (fn) => {
 
 const resetAllWhenMocks = () => {
   registry.forEach(fn => {
+    fn.mockImplementation(fn.__whenMock__._origMock);
     fn.__whenMock__ = undefined
   })
   registry = new Set()

--- a/src/when.js
+++ b/src/when.js
@@ -100,6 +100,12 @@ class WhenMock {
     this.calledWith = (...matchers) => ({ ...mockFunctions(matchers, false) })
 
     this.expectCalledWith = (...matchers) => ({ ...mockFunctions(matchers, true) })
+
+    this.resetWhenMocks = () => {
+      fn.mockImplementation(fn.__whenMock__._origMock);
+      fn.__whenMock__ = undefined;
+      registry.delete(fn);
+    }
   }
 }
 

--- a/src/when.js
+++ b/src/when.js
@@ -102,9 +102,9 @@ class WhenMock {
     this.expectCalledWith = (...matchers) => ({ ...mockFunctions(matchers, true) })
 
     this.resetWhenMocks = () => {
-      fn.mockImplementation(fn.__whenMock__._origMock);
-      fn.__whenMock__ = undefined;
-      registry.delete(fn);
+      fn.mockImplementation(fn.__whenMock__._origMock)
+      fn.__whenMock__ = undefined
+      registry.delete(fn)
     }
   }
 }
@@ -118,7 +118,7 @@ const when = (fn) => {
 
 const resetAllWhenMocks = () => {
   registry.forEach(fn => {
-    fn.mockImplementation(fn.__whenMock__._origMock);
+    fn.mockImplementation(fn.__whenMock__._origMock)
     fn.__whenMock__ = undefined
   })
   registry = new Set()

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -62,6 +62,16 @@ describe('When', () => {
       expect(fn(1)).toEqual('z')
     })
 
+    it('reset of mocks restores original implementation', () => {
+      const fn = jest.fn(() => 'a')
+
+      when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+      resetAllWhenMocks()
+
+      expect(fn(1)).toEqual('a')
+    })
+
     it('allows checking that all mocks were called', () => {
       const fn1 = jest.fn()
       const fn2 = jest.fn()

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -72,6 +72,16 @@ describe('When', () => {
       expect(fn(1)).toEqual('a')
     })
 
+    it('allows reset of mocks for one function', () => {
+      const fn = jest.fn(() => 'a')
+
+      const mock = when(fn).expectCalledWith(1).mockReturnValueOnce('x')
+
+      mock.resetWhenMocks()
+
+      expect(fn(1)).toEqual('a')
+    })
+
     it('allows checking that all mocks were called', () => {
       const fn1 = jest.fn()
       const fn2 = jest.fn()


### PR DESCRIPTION
to fix all calls to the mocked function returning undefined after calling `resetAllWhenMocks`
and add function `resetWhenMocks` to `WhenMock` to reset one mocked function's whenMocks