### PR TITLE
Support a default `mockImplentation()` and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ fn(2); // Will throw a helpful jest assertion error with args diff
 
 #### Supports default behavior
 
-Use any of `mockReturnValue`, `mockResolvedValue` or `mockRejectedValue` directly on the object
+Use any of `mockReturnValue`, `mockResolvedValue`, `mockRejectedValue`, `mockImplementation` directly on the object
 to set up a default behavior, which will serve as fallback if no matcher fits.
 
 ```javascript

--- a/src/when.js
+++ b/src/when.js
@@ -49,10 +49,11 @@ class WhenMock {
         .filter((callMock) => once || callMock.once || !utils.equals(callMock.matchers, matchers))
         .concat({ matchers, mockImplementation, expectCall, once, called: false, id: this.nextCallMockId, callLine: getCallLine() })
         .sort((a, b) => {
-          // Reduce their id by 1000 if they are a once mock, to sort them at the front
-          const aId = a.id - (a.once ? 1000 : 0)
-          const bId = b.id - (b.once ? 1000 : 0)
-          return aId - bId
+          // Once mocks should appear before the rest
+          if (a.once !== b.once) {
+            return a.once ? -1 : 1
+          }
+          return a.id - b.id
         })
 
       this.nextCallMockId++

--- a/src/when.js
+++ b/src/when.js
@@ -95,7 +95,8 @@ class WhenMock {
       mockImplementationOnce: implementation => _mockImplementation(matchers, expectCall, true)(implementation)
     })
 
-    this.mockReturnValue = returnValue => new WhenMock(fn, () => returnValue)
+    this.mockImplementation = mockImplementation => new WhenMock(fn, mockImplementation)
+    this.mockReturnValue = returnValue => this.mockImplementation(() => returnValue)
     this.mockResolvedValue = returnValue => this.mockReturnValue(Promise.resolve(returnValue))
     this.mockRejectedValue = err => this.mockReturnValue(Promise.reject(err))
 

--- a/src/when.js
+++ b/src/when.js
@@ -27,14 +27,14 @@ const checkArgumentMatchers = (expectCall, args) => (match, matcher, i) => {
   return utils.equals(arg, matcher)
 }
 class WhenMock {
-  constructor (fn, defaultValue = { isSet: false, returnValue: undefined }) {
+  constructor (fn, defaultImplementation = null) {
     // Incrementing ids assigned to each call mock to help with sorting as new mocks are added
     this.nextCallMockId = 0
     this.fn = fn
     this.callMocks = []
     this._origMock = fn.getMockImplementation()
 
-    if (defaultValue.isSet) {
+    if (defaultImplementation) {
       this.fn.mockImplementation(() => {
         throw new Error('Unintended use: Only use default value in combination with .calledWith(..), ' +
           'or use standard mocking without jest-when.')
@@ -63,6 +63,8 @@ class WhenMock {
         for (let i = 0; i < this.callMocks.length; i++) {
           const { matchers, mockImplementation, expectCall, once, called } = this.callMocks[i]
 
+          // TODO try them all first and then throw if found none
+
           // Do not let a once mock match more than once
           if (once && called) continue
 
@@ -73,7 +75,7 @@ class WhenMock {
           }
         }
 
-        return defaultValue.returnValue
+        return defaultImplementation ? defaultImplementation() : undefined
       })
 
       return {
@@ -93,7 +95,7 @@ class WhenMock {
       mockImplementationOnce: implementation => _mockImplementation(matchers, expectCall, true)(implementation)
     })
 
-    this.mockReturnValue = returnValue => new WhenMock(fn, { isSet: true, returnValue })
+    this.mockReturnValue = returnValue => new WhenMock(fn, () => returnValue)
     this.mockResolvedValue = returnValue => this.mockReturnValue(Promise.resolve(returnValue))
     this.mockRejectedValue = err => this.mockReturnValue(Promise.reject(err))
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -462,7 +462,7 @@ describe('When', () => {
       expect(fn('bar')).toEqual(false)
     })
 
-    it('has a default which is a function', () => {
+    it('has a default value which is a function', () => {
       const fn = jest.fn()
       const defaultValue = () => { }
 
@@ -471,6 +471,17 @@ describe('When', () => {
         .calledWith('bar').mockReturnValue('baz')
 
       expect(fn('foo')).toBe(defaultValue)
+    })
+
+    it('has a default implementation', () => {
+      const fn = jest.fn()
+
+      when(fn)
+        .mockImplementation(() => 1)
+        .calledWith('bar').mockReturnValue('baz')
+
+      expect(fn('foo')).toBe(1)
+      expect(fn('bar')).toBe('baz')
     })
 
     it('keeps the default with a lot of matchers', () => {


### PR DESCRIPTION
Make it possible to provide a default implementation in addition to a value. This is useful because it means I can have a

```js
when(spy).mockImplementation(() => {
  throw new Error('Unexpected call');
});
```
to make sure all expected calls are mocked out.

Also removes the magic number in the sorting.