### PR TITLE
do not match when too many args provided

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -66,7 +66,10 @@ class WhenMock {
           // Do not let a once mock match more than once
           if (once && called) continue
 
-          const isMatch = matchers.reduce(checkArgumentMatchers(expectCall, args), true)
+          const isMatch =
+            args.length <= matchers.length &&
+            matchers.reduce(checkArgumentMatchers(expectCall, args), true)
+
           if (isMatch) {
             this.callMocks[i].called = true
             return typeof returnValue === 'function' ? returnValue(...args) : returnValue

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -164,13 +164,22 @@ describe('When', () => {
         .mockReturnValue('x')
 
       expect(fn(1, 'foo', true, 'whatever')).toEqual('x')
-      expect(fn(1, 'foo', true)).toEqual(undefined)
-      expect(fn(1, 'foo', true, 'whatever', undefined, 'oops')).toEqual(undefined)
       expect(spyEquals).toBeCalledWith(1, 1)
       expect(spyEquals).toBeCalledWith('foo', 'foo')
       expect(spyEquals).toBeCalledWith(true, true)
       expect(spyEquals).toBeCalledWith('whatever', anyString)
       expect(spyEquals).toBeCalledWith(undefined, undefined)
+    })
+
+    it('only matches exact sets of args, too little or too many args do not trigger mock return', () => {
+      const fn = jest.fn()
+
+      when(fn)
+        .calledWith(1, 'foo', true, expect.any(String), undefined)
+        .mockReturnValue('x')
+
+      expect(fn(1, 'foo', true)).toEqual(undefined)
+      expect(fn(1, 'foo', true, 'whatever', undefined, 'oops')).toEqual(undefined)
     })
 
     it('supports compound when declarations', () => {

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -164,6 +164,8 @@ describe('When', () => {
         .mockReturnValue('x')
 
       expect(fn(1, 'foo', true, 'whatever')).toEqual('x')
+      expect(fn(1, 'foo', true)).toEqual(undefined)
+      expect(fn(1, 'foo', true, 'whatever', undefined, 'oops')).toEqual(undefined)
       expect(spyEquals).toBeCalledWith(1, 1)
       expect(spyEquals).toBeCalledWith('foo', 'foo')
       expect(spyEquals).toBeCalledWith(true, true)


### PR DESCRIPTION
I think this is a bug because if you really don't care what one of the last arguments is you could add an `expect.anything()`.

If you were expecting `n` arguments though then this makes it impossible right now.

Maybe we need a special marker to signal that you don't care about future args? Maybe something like

```js
when(fn1).expectCalledWith(1, when.anyRemainingArgs()).mockReturnValue('z')
```

WDYT?

