### PR TITLE
Allow users to access args in mockedImplementation method

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -74,7 +74,7 @@ class WhenMock {
           }
         }
 
-        return defaultImplementation ? defaultImplementation() : undefined
+        return defaultImplementation ? defaultImplementation(...args) : undefined
       })
 
       return {

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -484,6 +484,17 @@ describe('When', () => {
       expect(fn('bar')).toBe('baz')
     })
 
+    it('has access to args in a default implementation', () => {
+      const fn = jest.fn()
+
+      when(fn)
+        .mockImplementation(({ name }) => `Hello ${name}`)
+        .calledWith({ name: 'bar' }).mockReturnValue('Goodbye bar')
+
+      expect(fn({ name: 'foo' })).toBe('Hello foo')
+      expect(fn({ name: 'bar' })).toBe('Goodbye bar')
+    })
+
     it('keeps the default with a lot of matchers', () => {
       const fn = jest.fn()
 


### PR DESCRIPTION
A small addition to super nice PR from @tjenkinson. 🍻 
This PR adds the possibility for users to access args in the `mockImplementation` method.

Use case:
```javascript
when(spy).mockImplementation((name) => {
  throw new Error(`Unexpected call with name: ${name}`);
});
```