### PR TITLE
fix matching exact args

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -68,7 +68,7 @@ class WhenMock {
           if (once && called) continue
 
           const isMatch =
-            args.length <= matchers.length &&
+            args.length === matchers.length &&
             matchers.reduce(checkArgumentMatchers(expectCall, args), true)
 
           if (isMatch) {

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -160,14 +160,15 @@ describe('When', () => {
       const anyString = expect.any(String)
 
       when(fn)
-        .calledWith(1, 'foo', true, anyString)
+        .calledWith(1, 'foo', true, anyString, undefined)
         .mockReturnValue('x')
 
-      expect(fn(1, 'foo', true, 'whatever')).toEqual('x')
+      expect(fn(1, 'foo', true, 'whatever', undefined)).toEqual('x')
       expect(spyEquals).toBeCalledWith(1, 1)
       expect(spyEquals).toBeCalledWith('foo', 'foo')
       expect(spyEquals).toBeCalledWith(true, true)
       expect(spyEquals).toBeCalledWith('whatever', anyString)
+      expect(spyEquals).toBeCalledWith(undefined, undefined)
     })
 
     it('only matches exact sets of args, too little or too many args do not trigger mock return', () => {
@@ -177,7 +178,10 @@ describe('When', () => {
         .calledWith(1, 'foo', true, expect.any(String), undefined)
         .mockReturnValue('x')
 
+      expect(fn(1, 'foo', true, 'whatever', undefined)).toEqual('x')
+
       expect(fn(1, 'foo', true, 'whatever')).toEqual(undefined)
+      expect(fn(1, 'foo', true, 'whatever', undefined, undefined)).toEqual(undefined)
       expect(fn(1, 'foo', true, 'whatever', undefined, 'oops')).toEqual(undefined)
     })
 

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -160,7 +160,7 @@ describe('When', () => {
       const anyString = expect.any(String)
 
       when(fn)
-        .calledWith(1, 'foo', true, anyString, undefined)
+        .calledWith(1, 'foo', true, anyString)
         .mockReturnValue('x')
 
       expect(fn(1, 'foo', true, 'whatever')).toEqual('x')
@@ -168,7 +168,6 @@ describe('When', () => {
       expect(spyEquals).toBeCalledWith('foo', 'foo')
       expect(spyEquals).toBeCalledWith(true, true)
       expect(spyEquals).toBeCalledWith('whatever', anyString)
-      expect(spyEquals).toBeCalledWith(undefined, undefined)
     })
 
     it('only matches exact sets of args, too little or too many args do not trigger mock return', () => {
@@ -178,7 +177,7 @@ describe('When', () => {
         .calledWith(1, 'foo', true, expect.any(String), undefined)
         .mockReturnValue('x')
 
-      expect(fn(1, 'foo', true)).toEqual(undefined)
+      expect(fn(1, 'foo', true, 'whatever')).toEqual(undefined)
       expect(fn(1, 'foo', true, 'whatever', undefined, 'oops')).toEqual(undefined)
     })
 


### PR DESCRIPTION
I got the test wrong in https://github.com/timkindberg/jest-when/pull/52 🤦 