### PR TITLE
Keep original function implementation when not matched

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -96,8 +96,9 @@ class WhenMock {
             return mockImplementation(...args)
           }
         }
-
-        return defaultImplementation ? defaultImplementation(...args) : undefined
+        return defaultImplementation ? defaultImplementation(...args)
+          : (typeof fn.__whenMock__._origMock === 'function'
+            ? fn.__whenMock__._origMock(...args) : undefined)
       })
 
       return {

--- a/src/when.test.js
+++ b/src/when.test.js
@@ -835,5 +835,30 @@ describe('When', () => {
       const returnValue = theInstance.theMethod(1)
       expect(returnValue).toBe('mock')
     })
+
+    it('keeps default function implementation when not matched', () => {
+      class TheClass {
+        fn () {
+          return 'real'
+        }
+      }
+      const instance = new TheClass()
+      const spy = jest.spyOn(instance, 'fn')
+      when(spy)
+        .calledWith(1)
+        .mockReturnValue('mock')
+      expect(instance.fn(2)).toBe('real')
+    })
+
+    it('keeps default mock implementation when not matched', () => {
+      const fn = jest.fn(() => {
+        return 'real'
+      })
+      when(fn)
+        .calledWith(1)
+        .mockReturnValue('mock')
+      expect(fn(1)).toBe('mock')
+      expect(fn(2)).toBe('real')
+    })
   })
 })


### PR DESCRIPTION
resolves #78

imo this is also more in line with the jest default behavior