### PR TITLE
Add .npmignore to keep published package slim

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+# Ignore everything
+*
+
+# Publish from an allowlist
+src/**/*.js
+!src/**/*.test.js
+LICENSE
+package.json
+README.md


### PR DESCRIPTION
Create the `.npmignore` file with an allowlist of files that should be published. I went with an "allowlist" approach to avoid files added in the future, as well as files that happen to exist at the time of publishing, from being included in the published packages.

I've never used yarn when publishing a package so I'm not 100% sure this will work, but from what I could find online it seems this should work.

---

For reference, this is what the installed package currently looks like:

```shell
$ npm ls jest-when
example@3.1.0 /path/to/example
└── jest-when@3.5.2

$ l node_modules/jest-when
.eslintignore
.eslintrc
LICENSE
package.json
README.md
src
stryker.conf.js
.tool-versions
.travis.yml

$ l node_modules/jest-when/src
when.js
when.test.js
```

And here's what it would look like after this change:

```shell
$ l node_modules/jest-when
LICENSE
package.json
README.md
src

$ l node_modules/jest-when/src 
when.js
```