### PR TITLE
Remove a layer of indirection for defaultRejectedValue

### DIFF
--- a/src/when.js
+++ b/src/when.js
@@ -154,7 +154,7 @@ class WhenMock {
     }
     this.defaultReturnValue = returnValue => this.defaultImplementation(() => returnValue)
     this.defaultResolvedValue = returnValue => this.defaultReturnValue(Promise.resolve(returnValue))
-    this.defaultRejectedValue = err => this.defaultResolvedValue(Promise.reject(err))
+    this.defaultRejectedValue = err => this.defaultReturnValue(Promise.reject(err))
     this.mockImplementation = this.defaultImplementation
     this.mockReturnValue = this.defaultReturnValue
     this.mockResolvedValue = this.defaultResolvedValue


### PR DESCRIPTION
Came across this while evaluating the library -- it looks like it was inadvertently doing `Promise.resolve(Promise.reject(err))`. That's mostly equivalent enough to `Promise.reject(err)`, but we might as well just do the simple thing.