### PR TITLE
fix(types): resolve generic conditional return types (fixes #113)

### DIFF
--- a/src/when.ts
+++ b/src/when.ts
@@ -608,12 +608,27 @@ type FunctionFromMockLike<T> = T extends { mockImplementation(fn?: infer TImplem
   ? ExtractFunction<TImplementation>
   : never;
 
+// Infer `TArgs` inline (so it stays constrained to `any[]` for
+// `WhenMock<..., TArgs extends any[]>`) but resolve the return type through
+// the built-in `ReturnType` utility. When T is a generic function (e.g.
+// `<U>(x: U) => SomeConditional<U>`), inferring both positions at once keeps
+// the underlying generic as a free type parameter, which leaves conditional
+// / mapped return types (like `{ [K in keyof U]: U[K] extends X ? A : B }`)
+// deferred and prevents `mockReturnValue(...)` callers from supplying a valid
+// value. Running the return type through `ReturnType<...>` separately forces
+// TypeScript to resolve the underlying generic with its constraint, matching
+// how the function would be typed if called directly. See issue #113.
+type SafeReturnType<T> = T extends (...args: any) => any ? ReturnType<T> : never;
+
 type Whenified<T> = [FunctionFromMockLike<T>] extends [never]
-  ? T extends (...args: infer TArgs) => infer TReturn
-    ? WhenMock<NormalizeReturn<TReturn>, NormalizeArgs<TArgs>>
+  ? T extends (...args: infer TArgs) => any
+    ? WhenMock<NormalizeReturn<SafeReturnType<T>>, NormalizeArgs<TArgs>>
     : never
-  : FunctionFromMockLike<T> extends (...args: infer TArgs) => infer TReturn
-    ? WhenMock<NormalizeReturn<TReturn>, NormalizeArgs<TArgs>>
+  : FunctionFromMockLike<T> extends (...args: infer TArgs) => any
+    ? WhenMock<
+        NormalizeReturn<SafeReturnType<FunctionFromMockLike<T>>>,
+        NormalizeArgs<TArgs>
+      >
     : never;
 
 /**

--- a/src/when.type-test.ts
+++ b/src/when.type-test.ts
@@ -382,3 +382,89 @@ type MockedObjectMethod<TFunc extends (...args: any[]) => any> = TFunc & {
   expectTypeOf(w.mockReturnValueOnce(1)).toEqualTypeOf<WhenMock<number, [string]> & WhenMockWithMatchers<number, [string]>>();
   expectTypeOf(w.mockReset()).toEqualTypeOf<WhenMock<number, [string]>>();
 }
+
+// Generic functions with conditional / mapped return types (issue #113).
+// Before the fix, `infer TArgs` + `infer TReturn` in Whenified kept the
+// underlying function's generic as a free type parameter, which left
+// conditional types like `T[K] extends X ? A : B` deferred and caused
+// assignment failures on `.mockReturnValue(...)`.
+{
+  type PrepareInputsArrayValue = (string | number)[];
+  type PrepareInputsValue = string | number;
+
+  // Exact reproduction from issue #113
+  const problemFunction = jest.fn() as <
+    T extends Record<string, PrepareInputsArrayValue | PrepareInputsValue>,
+  >(
+    fields?: T,
+  ) => { [K in keyof T]: T[K] extends PrepareInputsArrayValue ? string[] : string };
+
+  const input = { a: 1, b: [2, 3] };
+
+  when(problemFunction)
+    .expectCalledWith(input)
+    .mockReturnValue({ a: '1', b: ['2', '3'] });
+
+  when(problemFunction)
+    .calledWith(input)
+    .mockReturnValue({ a: '1', b: ['2', '3'] });
+}
+
+// Generic function with mapped return type
+{
+  const mapify = jest.fn() as <T extends object>(obj: T) => { [K in keyof T]: T[K] };
+
+  when(mapify).calledWith({ a: 1 }).mockReturnValue({ a: 1 });
+  when(mapify).expectCalledWith({ a: 1, b: 'two' }).mockReturnValue({ a: 1, b: 'two' });
+}
+
+// Generic function returning a promise of a conditional type
+{
+  const asyncProblem = jest.fn() as <
+    T extends Record<string, number | number[]>,
+  >(
+    fields: T,
+  ) => Promise<{ [K in keyof T]: T[K] extends number[] ? string[] : string }>;
+
+  when(asyncProblem)
+    .calledWith({ a: 1, b: [2, 3] })
+    .mockResolvedValue({ a: '1', b: ['2', '3'] });
+
+  when(asyncProblem)
+    .expectCalledWith({ a: 1, b: [2, 3] })
+    .mockResolvedValue({ a: '1', b: ['2', '3'] });
+}
+
+// Generic identity function — the generic should not leak through args either
+{
+  const identity = jest.fn() as <T>(x: T) => T;
+
+  when(identity).calledWith(42).mockReturnValue(42);
+  when(identity).calledWith('hello').mockReturnValue('hello');
+}
+
+// Generic function wrapped via jest.mocked
+{
+  const rawFn = ((() => {}) as unknown) as <
+    T extends Record<string, number | number[]>,
+  >(
+    fields: T,
+  ) => { [K in keyof T]: T[K] extends number[] ? string[] : string };
+
+  when(jest.mocked(rawFn))
+    .calledWith({ a: 1, b: [2, 3] })
+    .mockReturnValue({ a: '1', b: ['2', '3'] });
+}
+
+// mockImplementation on a generic function with conditional return type
+{
+  const problem = jest.fn() as <
+    T extends Record<string, number | number[]>,
+  >(
+    fields: T,
+  ) => { [K in keyof T]: T[K] extends number[] ? string[] : string };
+
+  when(problem)
+    .calledWith({ a: 1, b: [2, 3] })
+    .mockImplementation(() => ({ a: '1', b: ['2', '3'] }));
+}


### PR DESCRIPTION
## Summary

Fixes #113 — `when()` could not type-check `.mockReturnValue(...)` calls on generic functions whose return type is a conditional or mapped type over the generic (e.g. `<T>(fields: T) => { [K in keyof T]: T[K] extends X ? A : B }`).

### Root cause

`Whenified<T>` previously used a single inline inference:

```ts
T extends (...args: infer TArgs) => infer TReturn
  ? WhenMock<NormalizeReturn<TReturn>, NormalizeArgs<TArgs>>
  : never
```

Inferring both positions at once keeps the underlying generic (e.g. the function-level `T`) as a free type parameter shared between `TArgs` and `TReturn`. As a result, conditional / mapped return types like `{ [K in keyof T]: T[K] extends X ? A : B }` remain deferred. TypeScript then checks `.mockReturnValue({ a: '1', b: ['2', '3'] })` against a conditional it cannot resolve and reports errors such as `Type 'string[]' is not assignable to type 'string'` — even though the same value is assignable when the function is called directly.

### Fix

Keep `TArgs` inferred inline (so it stays constrained to `any[]`, which is important for TS 4.x — matters for the `jest27` compat workspace), but route the return type through the built-in `ReturnType<...>` utility via a small `SafeReturnType<T>` guard:

```ts
type SafeReturnType<T> = T extends (...args: any) => any ? ReturnType<T> : never;

type Whenified<T> = [FunctionFromMockLike<T>] extends [never]
  ? T extends (...args: infer TArgs) => any
    ? WhenMock<NormalizeReturn<SafeReturnType<T>>, NormalizeArgs<TArgs>>
    : never
  : FunctionFromMockLike<T> extends (...args: infer TArgs) => any
    ? WhenMock<
        NormalizeReturn<SafeReturnType<FunctionFromMockLike<T>>>,
        NormalizeArgs<TArgs>
      >
    : never;
```

Breaking the inference between args and return type forces TypeScript to resolve the underlying generic with its constraint when computing the return type, matching how the function would be typed if you invoked it directly.

### Tests (TDD)

Added type tests in `src/when.type-test.ts` covering:

- The exact repro from #113 — generic with conditional mapped return type via `expectCalledWith` + `mockReturnValue`, and the `calledWith` variant.
- Generic function with a plain mapped return type.
- Generic async function with conditional return + `mockResolvedValue` / `expectCalledWith`.
- Generic identity `<T>(x: T) => T` (guard against args-side regressions).
- Generic function wrapped via `jest.mocked(...)`.
- `mockImplementation` on the same generic conditional shape.

All previously passing type tests still pass, as do the 89 runtime Jest tests and the `jest27` compatibility workspace (tested against TypeScript 4.9.5 as well as the main 5.9 typecheck).

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm test` — 89/89 pass.
- [x] `npm run lint` passes.
- [x] `npm run build` passes.
- [x] `npm run verify:jest27` passes (TS 4.9.5 compat).
- [x] New type tests in `src/when.type-test.ts` fail without the fix and pass with it.

https://claude.ai/code/session_01C1ZK62CsK7hzDjXce4URBx