### PR TITLE
regression: .defaultImplementation() silently dropped prior bare .calledWith() mocks

### DIFF
--- a/src/when.test.ts
+++ b/src/when.test.ts
@@ -831,6 +831,49 @@ describe('When', () => {
 
           expect(fn()).toEqual(2);
         });
+
+        it('preserves a prior bare .calledWith() when followed by .defaultImplementation()', () => {
+          const fn = jest.fn();
+
+          when(fn)
+            .calledWith().mockReturnValue('no-args')
+            .defaultImplementation(() => 'default');
+
+          expect(fn()).toBe('no-args');
+          expect(fn('x')).toBe('default');
+        });
+
+        it('preserves a prior .calledWith(undefined) registration when followed by .defaultImplementation()', () => {
+          const fn = jest.fn();
+
+          when(fn)
+            .calledWith(undefined).mockReturnValue('one-undef')
+            .defaultImplementation(() => 'default');
+
+          expect(fn(undefined)).toBe('one-undef');
+          expect(fn('x')).toBe('default');
+        });
+
+        it('preserves a prior .calledWith(undefined, undefined) registration when followed by .defaultImplementation()', () => {
+          const fn = jest.fn();
+
+          when(fn)
+            .calledWith(undefined, undefined).mockReturnValue('two-undef')
+            .defaultImplementation(() => 'default');
+
+          expect(fn(undefined, undefined)).toBe('two-undef');
+          expect(fn('x')).toBe('default');
+        });
+
+        it('still allows .defaultImplementation() to be replaced by a later .defaultImplementation()', () => {
+          const fn = jest.fn();
+
+          when(fn)
+            .defaultImplementation(() => 'first')
+            .defaultImplementation(() => 'second');
+
+          expect(fn('anything')).toBe('second');
+        });
       });
 
       describe('legacy methods', () => {

--- a/src/when.ts
+++ b/src/when.ts
@@ -29,6 +29,15 @@ let registry = new Set<jest.Mock | jest.SpyInstance>();
 const getCallLines = (): string => (new Error()).stack!.split('\n').slice(4).join('\n');
 
 /**
+ * @internal Sentinel matcher used by `defaultImplementation`. Module-private so it
+ * can never deep-equal any user-provided matcher, which keeps the dynamic-replacement
+ * filter in `_mockImplementation` from dropping legitimate bare `.calledWith()` /
+ * `.calledWith(undefined, ...)` registrations made before a default. Restored from
+ * the pre-TS-port JS implementation (commit cc6ca58).
+ */
+const NO_CALLED_WITH_YET = Symbol('NO_CALLED_WITH');
+
+/**
  * A hack to capture a reference to the `equals` jasmineUtil
  * @internal
  */
@@ -263,7 +272,7 @@ export class WhenMock<TReturn = any, TArgs extends any[] = any[]> {
    */
   defaultImplementation: (mockImplementation: (...args: TArgs) => TReturn) => WhenMockChain<TReturn, TArgs> = (mockImplementation) => {
     this.__noCalledWithYet = true;
-    this._matchers = [];
+    this._matchers = [NO_CALLED_WITH_YET];
     this._expectCall = false;
     // Set up an implementation with a special matcher that can never be matched because it uses a private symbol
     // Additionally the symbols existence can be checked to see if a calledWith was omitted.
@@ -523,38 +532,31 @@ export class WhenMock<TReturn = any, TArgs extends any[] = any[]> {
   /** @internal The function to call when the mock is called */
   private _mockImplementation = (mockImplementation: (...args: any[]) => any) => {
     if (this.__noCalledWithYet) {
-      // Default implementations live in their own slot and are consulted as a
-      // fallback by the runtime when no `calledWith` matcher matches. We deliberately
-      // do NOT add a phantom entry to `callMocks` here: jest's deep-equals treats
-      // `[]`, `[undefined]`, `[undefined, undefined]`, ... as equal, so the
-      // filter below would silently drop legitimate bare `.calledWith()` /
-      // `.calledWith(undefined, ...)` registrations made before this default.
       this._defaultImplementation = mockImplementation;
-    } else {
-      // To enable dynamic replacement during a test:
-      // * call mocks with equal matchers are removed
-      // * `once` mocks are prioritized
-      this.callMocks = this.callMocks
-        .filter((callMock) => this._once || callMock.once || !equals(callMock.matchers, this._matchers))
-        .concat({
-            matchers: this._matchers,
-            mockImplementation,
-            expectCall: this._expectCall,
-            once: this._once,
-            called: false,
-            id: this.nextCallMockId,
-            callLines: getCallLines()
-        })
-        .sort((a, b) => {
-          // Once mocks should appear before the rest
-          if (a.once !== b.once) {
-            return a.once ? -1 : 1;
-          }
-          return a.id - b.id;
-        });
-
-      this.nextCallMockId++;
     }
+    // To enable dynamic replacement during a test:
+    // * call mocks with equal matchers are removed
+    // * `once` mocks are prioritized
+    this.callMocks = this.callMocks
+      .filter((callMock) => this._once || callMock.once || !equals(callMock.matchers, this._matchers))
+      .concat({
+          matchers: this._matchers,
+          mockImplementation,
+          expectCall: this._expectCall,
+          once: this._once,
+          called: false,
+          id: this.nextCallMockId,
+          callLines: getCallLines()
+      })
+      .sort((a, b) => {
+        // Once mocks should appear before the rest
+        if (a.once !== b.once) {
+          return a.once ? -1 : 1;
+        }
+        return a.id - b.id;
+      });
+
+    this.nextCallMockId++;
     this._once = false;
 
     const instance = this;

--- a/src/when.ts
+++ b/src/when.ts
@@ -523,31 +523,38 @@ export class WhenMock<TReturn = any, TArgs extends any[] = any[]> {
   /** @internal The function to call when the mock is called */
   private _mockImplementation = (mockImplementation: (...args: any[]) => any) => {
     if (this.__noCalledWithYet) {
+      // Default implementations live in their own slot and are consulted as a
+      // fallback by the runtime when no `calledWith` matcher matches. We deliberately
+      // do NOT add a phantom entry to `callMocks` here: jest's deep-equals treats
+      // `[]`, `[undefined]`, `[undefined, undefined]`, ... as equal, so the
+      // filter below would silently drop legitimate bare `.calledWith()` /
+      // `.calledWith(undefined, ...)` registrations made before this default.
       this._defaultImplementation = mockImplementation;
-    }
-    // To enable dynamic replacement during a test:
-    // * call mocks with equal matchers are removed
-    // * `once` mocks are prioritized
-    this.callMocks = this.callMocks
-      .filter((callMock) => this._once || callMock.once || !equals(callMock.matchers, this._matchers))
-      .concat({ 
-          matchers: this._matchers, 
-          mockImplementation, 
-          expectCall: this._expectCall, 
-          once: this._once, 
-          called: false, 
-          id: this.nextCallMockId, 
-          callLines: getCallLines() 
-      })
-      .sort((a, b) => {
-        // Once mocks should appear before the rest
-        if (a.once !== b.once) {
-          return a.once ? -1 : 1;
-        }
-        return a.id - b.id;
-      });
+    } else {
+      // To enable dynamic replacement during a test:
+      // * call mocks with equal matchers are removed
+      // * `once` mocks are prioritized
+      this.callMocks = this.callMocks
+        .filter((callMock) => this._once || callMock.once || !equals(callMock.matchers, this._matchers))
+        .concat({
+            matchers: this._matchers,
+            mockImplementation,
+            expectCall: this._expectCall,
+            once: this._once,
+            called: false,
+            id: this.nextCallMockId,
+            callLines: getCallLines()
+        })
+        .sort((a, b) => {
+          // Once mocks should appear before the rest
+          if (a.once !== b.once) {
+            return a.once ? -1 : 1;
+          }
+          return a.id - b.id;
+        });
 
-    this.nextCallMockId++;
+      this.nextCallMockId++;
+    }
     this._once = false;
 
     const instance = this;


### PR DESCRIPTION
# Fix: `.defaultImplementation()` silently dropped prior bare `.calledWith()` mocks

## What was broken

Calling `.defaultImplementation()` (or its aliases `.defaultReturnValue()` / `.defaultResolvedValue()` / `.defaultRejectedValue()`) after a bare `.calledWith()` would silently discard the earlier registration:

```js
const fn = jest.fn();
when(fn)
  .calledWith().mockReturnValue('A')
  .defaultImplementation(() => 'B');

fn();      // expected 'A', actually returned 'B'
```

The same happened for `.calledWith(undefined)`, `.calledWith(undefined, undefined)`, and so on.

## Why

`_mockImplementation` filters `callMocks` by `equals(callMock.matchers, this._matchers)` to support dynamic re-registration. `defaultImplementation` set `this._matchers = []` before routing through that path, and Jest's deep equality treats `[]`, `[undefined]`, `[undefined, undefined]`, … as equal (trailing-`undefined` array slots are ignored). So every previously-registered no-arg / all-`undefined`-arg mock matched the filter and was dropped.

Wrapping the matchers with `when.allArgs(...)` worked around it because the matcher then became a function object, taking a different equality path.

## The fix

Restore the module-private `Symbol` sentinel that the TS port (`142f297`) accidentally dropped. The pre-port JS code marked default registrations with `[NO_CALLED_WITH_YET]` — a module-scoped `Symbol` that, by construction, can never deep-equal any user-provided matcher, so the dynamic-replacement filter is guaranteed not to evict legitimate `.calledWith()` registrations. The TS port replaced it with `[]` while preserving the original comment ("special matcher that can never be matched because it uses a private symbol"); this PR makes the code match what the comment has always claimed.

Three small changes in `src/when.ts`:
1. Add `const NO_CALLED_WITH_YET = Symbol('NO_CALLED_WITH')` at module scope.
2. `defaultImplementation` sets `this._matchers = [NO_CALLED_WITH_YET]` instead of `[]`.
3. `_mockImplementation` runs its existing filter+concat unchanged — now safe again because the sentinel cannot collide.

The phantom `callMocks` entry the default still produces never matches a real call (the length check rules out 0-arg calls; the `equals(arg, NO_CALLED_WITH_YET)` check rules out everything else), so the runtime fallback to `_defaultImplementation` is reached exactly as before.

## Tests

Added regression coverage for:
- bare `.calledWith()` followed by `.defaultImplementation()`
- `.calledWith(undefined)` / `.calledWith(undefined, undefined)` followed by `.defaultImplementation()`
- `.defaultImplementation()` overriding a prior `.defaultImplementation()`

## Regression point

Introduced in `142f297` (the TypeScript port, #111). The previous JS implementation marked default registrations with a private-symbol sentinel `[NO_CALLED_WITH_YET]` (added in `cc6ca58` precisely to avoid this collision). The port swapped the sentinel for `[]` while preserving the original comment ("special matcher that can never be matched because it uses a private symbol"), which no longer matches the code.

## Not addressed in this PR

`mockReset()` uses the same equality-based filter and likely has an analogous edge case (bare `.calledWith().mockReset()` would over-match `.calledWith(undefined)` registrations). Out of scope here; happy to follow up separately.
